### PR TITLE
Add maven compiler plugin

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -33,4 +33,13 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+    
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/demo/pom.xml
+++ b/demo/pom.xml
@@ -52,6 +52,10 @@
                     <mainClass>com.dooapp.fxform.Demo</mainClass>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -69,5 +69,21 @@
             <url>http://repository.jboss.org/nexus/content/groups/public-jboss/</url>
         </repository>
     </repositories>
+    
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>2.3.2</version>
+                    <configuration>
+                        <source>1.6</source>
+                        <target>1.6</target>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
 
 </project>


### PR DESCRIPTION
Add maven compiler plugin and configure it to use Java 6 because of using the @override annotation on methods that implement those declared by an interface is only valid from Java 6 onward. It's an error in Java 5 and if you compile FXForm with Java 5, it's failed.
