### PR TITLE
Exclude filtered fields validation

### DIFF
--- a/core/src/main/java/com/dooapp/fxform/validation/ClassLevelValidator.java
+++ b/core/src/main/java/com/dooapp/fxform/validation/ClassLevelValidator.java
@@ -64,7 +64,7 @@ public class ClassLevelValidator {
         Set<ConstraintViolation> violationSetRelatingToElements = new HashSet<>();
         // for each violation, check if this violation relates to some specific field, or if it should be treated as a
         // class violation  (see #92)
-        for (Element element : abstractFXForm.getElements()) {
+        for (Element element : abstractFXForm.getFilteredElements()) {
             PropertyElementValidator propertyElementValidator = getElementValidator(element, abstractFXForm);
             if (propertyElementValidator != null) {
                 List<ConstraintViolation> elementViolations = propertyElementValidator.reportClassLevelConstraintViolation(violationList);


### PR DESCRIPTION
Simple scenario: create a Pojo with 2 properties "A" and "B". Create an FXForm for this Pojo and add a new ExcludeFilder("B"). The only field displayed is A. 

Now type some text in the field A. This will trigger the validate() method of ClassLevelValidator to be called. A null pointer exception will be thrown, because it will attempt to retrieve the controller for the excluded field element, which is null, before the element was never created.