### PR TITLE
Fix StackOverflowException when loading bean with no-property fields due to #154

### DIFF
--- a/core/src/main/java/com/dooapp/fxform/model/impl/AbstractFieldElement.java
+++ b/core/src/main/java/com/dooapp/fxform/model/impl/AbstractFieldElement.java
@@ -62,7 +62,7 @@ public abstract class AbstractFieldElement<SourceType, WrappedType> extends Abst
 
 	@Override
 	protected Binding<ObservableValue<WrappedType>> createValue() {
-		if (List.class.isAssignableFrom(getType())) {
+		if (List.class.isAssignableFrom(field.getType())) {
 			return new ListBinding() {
 				{
 					super.bind(sourceProperty());
@@ -82,7 +82,7 @@ public abstract class AbstractFieldElement<SourceType, WrappedType> extends Abst
 					unbind(sourceProperty());
 				}
 			};
-		} else if (Map.class.isAssignableFrom(getType())) {
+		} else if (Map.class.isAssignableFrom(field.getType())) {
 			return new MapBinding() {
 				{
 					super.bind(sourceProperty());

--- a/core/src/test/java/com/dooapp/fxform/issues/Issue155Test.java
+++ b/core/src/test/java/com/dooapp/fxform/issues/Issue155Test.java
@@ -1,0 +1,30 @@
+package com.dooapp.fxform.issues;
+
+import com.dooapp.fxform.FXForm;
+import com.dooapp.fxform.JavaFXRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class Issue155Test {
+
+    @Rule
+    public JavaFXRule javaFXRule = new JavaFXRule();
+
+    public class TestBean {
+        private Object object = new Object();
+
+        public Object getObject() {
+            return object;
+        }
+
+        public void setObject(Object object) {
+            this.object = object;
+        }
+    }
+
+    @Test
+    public void testIssue155() {
+        TestBean testBean = new TestBean();
+        FXForm form = new FXForm(testBean);
+    }
+}

--- a/core/src/test/java/com/dooapp/fxform/issues/Issue156Test.java
+++ b/core/src/test/java/com/dooapp/fxform/issues/Issue156Test.java
@@ -5,7 +5,7 @@ import com.dooapp.fxform.JavaFXRule;
 import org.junit.Rule;
 import org.junit.Test;
 
-public class Issue155Test {
+public class Issue156Test {
 
     @Rule
     public JavaFXRule javaFXRule = new JavaFXRule();
@@ -23,7 +23,7 @@ public class Issue155Test {
     }
 
     @Test
-    public void testIssue155() {
+    public void testIssue156() {
         TestBean testBean = new TestBean();
         FXForm form = new FXForm(testBean);
     }


### PR DESCRIPTION
This commit fix the following stracktrace : 
```java
java.lang.StackOverflowError: null
	at com.dooapp.fxform.model.impl.java.AbstractJavaBeanElement.getType(AbstractJavaBeanElement.java:72) ~[dsdk-launcher.jar:na]
	at com.dooapp.fxform.model.impl.AbstractFieldElement.createValue(AbstractFieldElement.java:65) ~[dsdk-launcher.jar:na]
	at com.dooapp.fxform.model.impl.AbstractSourceElement.wrappedProperty(AbstractSourceElement.java:131) ~[dsdk-launcher.jar:na]
	at com.dooapp.fxform.model.impl.java.AbstractJavaBeanElement.getType(AbstractJavaBeanElement.java:72) ~[dsdk-launcher.jar:na]
	at com.dooapp.fxform.model.impl.AbstractFieldElement.createValue(AbstractFieldElement.java:65) ~[dsdk-launcher.jar:na]
	at com.dooapp.fxform.model.impl.AbstractSourceElement.wrappedProperty(AbstractSourceElement.java:131) ~[dsdk-launcher.jar:na]
	at com.dooapp.fxform.model.impl.java.AbstractJavaBeanElement.getType(AbstractJavaBeanElement.java:72) ~[dsdk-launcher.jar:na]
	at com.dooapp.fxform.model.impl.AbstractFieldElement.createValue(AbstractFieldElement.java:65) ~[dsdk-launcher.jar:na]
	at com.dooapp.fxform.model.impl.AbstractSourceElement.wrappedProperty(AbstractSourceElement.java:131) ~[dsdk-launcher.jar:na]
	at com.dooapp.fxform.model.impl.java.AbstractJavaBeanElement.getType(AbstractJavaBeanElement.java:72) ~[dsdk-launcher.jar:na]
	at com.dooapp.fxform.model.impl.AbstractFieldElement.createValue(AbstractFieldElement.java:65) ~[dsdk-launcher.jar:na]
	at com.dooapp.fxform.model.impl.AbstractSourceElement.wrappedProperty(AbstractSourceElement.java:131) ~[dsdk-launcher.jar:na]
	at com.dooapp.fxform.model.impl.java.AbstractJavaBeanElement.getType(AbstractJavaBeanElement.java:72) ~[dsdk-launcher.jar:na]
	at com.dooapp.fxform.model.impl.AbstractFieldElement.createValue(AbstractFieldElement.java:65) ~[dsdk-launcher.jar:na]
	at com.dooapp.fxform.model.impl.AbstractSourceElement.wrappedProperty(AbstractSourceElement.java:131) ~[dsdk-launcher.jar:na]
	at com.dooapp.fxform.model.impl.java.AbstractJavaBeanElement.getType(AbstractJavaBeanElement.java:72) ~[dsdk-launcher.jar:na]
	[...]
```