### PR TITLE
Fix potential memory leak in DefaultAdapterProvider

### DIFF
--- a/core/src/main/java/com/dooapp/fxform/adapter/DefaultAdapterMatcher.java
+++ b/core/src/main/java/com/dooapp/fxform/adapter/DefaultAdapterMatcher.java
@@ -1,0 +1,12 @@
+package com.dooapp.fxform.adapter;
+
+import com.dooapp.fxform.model.Element;
+import com.dooapp.fxform.view.FXFormNode;
+
+public class DefaultAdapterMatcher implements AdapterMatcher {
+
+    @Override
+    public boolean matches(Class fromClass, Class toClass, Element element, FXFormNode fxFormNode) {
+        return fromClass.isAssignableFrom(toClass);
+    }
+}

--- a/core/src/main/java/com/dooapp/fxform/adapter/DefaultAdapterProvider.java
+++ b/core/src/main/java/com/dooapp/fxform/adapter/DefaultAdapterProvider.java
@@ -39,12 +39,10 @@ public class DefaultAdapterProvider implements AdapterProvider {
     private final Map<AdapterMatcher, Adapter> USER_MAP = new ConcurrentHashMap<>();
 
     {
-        DEFAULT_MAP.put(new AdapterMatcher() {
-            @Override
-            public boolean matches(Class fromClass, Class toClass, Element element, FXFormNode fxFormNode) {
-                return fromClass.isAssignableFrom(toClass);
-            }
-        }, new DefaultAdapter());
+        // Make sure to not add a new adapter as anonymous inner class in the DEFAULT_MAP.
+        // That could cause memory leak since an inner instance keeps a reference to its outer instance.
+
+        DEFAULT_MAP.put(new DefaultAdapterMatcher(), new DefaultAdapter());
 
         DEFAULT_MAP.put(new TypeAdapterMatcher(IntegerProperty.class, StringProperty.class),
                 new ConverterWrapper(new IntegerStringConverter()));
@@ -61,40 +59,17 @@ public class DefaultAdapterProvider implements AdapterProvider {
         DEFAULT_MAP.put(new ObjectPropertyAdapterMatcher(BigDecimal.class, StringProperty.class),
                 new ConverterWrapper(new BigDecimalStringConverter()));
         DEFAULT_MAP.put(new TypeAdapterMatcher(IntegerProperty.class, DoubleProperty.class),
-                new Adapter<Integer, Double>() {
-
-                    @Override
-                    public Double adaptTo(Integer from) {
-                        return from.doubleValue();
-                    }
-
-                    @Override
-                    public Integer adaptFrom(Double to) {
-                        return to.intValue();
-                    }
-                });
+                new IntegerToDoubleAdapter());
         DEFAULT_MAP.put(new TypeAdapterMatcher(FloatProperty.class, DoubleProperty.class),
-                new Adapter<Float, Double>() {
-
-                    @Override
-                    public Double adaptTo(Float from) {
-                        return from.doubleValue();
-                    }
-
-                    @Override
-                    public Float adaptFrom(Double to) {
-                        return to.floatValue();
-                    }
-                });
+                new FloatToDoubleAdapter());
+        DEFAULT_MAP.put(new TypeAdapterMatcher(ObjectProperty.class, StringProperty.class),
+                new ToStringConverter());
 
         DEFAULT_MAP.put(new PropertyTypeMatcher(StringProperty.class), new DefaultAdapter());
         DEFAULT_MAP.put(new PropertyTypeMatcher(IntegerProperty.class), new DefaultAdapter());
         DEFAULT_MAP.put(new PropertyTypeMatcher(FloatProperty.class), new DefaultAdapter());
         DEFAULT_MAP.put(new PropertyTypeMatcher(DoubleProperty.class), new DefaultAdapter());
         DEFAULT_MAP.put(new PropertyTypeMatcher(BooleanProperty.class), new DefaultAdapter());
-
-        DEFAULT_MAP.put(new TypeAdapterMatcher(ObjectProperty.class, StringProperty.class),
-                new ToStringConverter());
     }
 
     @Override

--- a/core/src/main/java/com/dooapp/fxform/adapter/FloatToDoubleAdapter.java
+++ b/core/src/main/java/com/dooapp/fxform/adapter/FloatToDoubleAdapter.java
@@ -1,0 +1,14 @@
+package com.dooapp.fxform.adapter;
+
+public class FloatToDoubleAdapter implements Adapter<Float, Double> {
+
+    @Override
+    public Double adaptTo(Float from) {
+        return from.doubleValue();
+    }
+
+    @Override
+    public Float adaptFrom(Double to) {
+        return to.floatValue();
+    }
+}

--- a/core/src/main/java/com/dooapp/fxform/adapter/IntegerToDoubleAdapter.java
+++ b/core/src/main/java/com/dooapp/fxform/adapter/IntegerToDoubleAdapter.java
@@ -1,0 +1,14 @@
+package com.dooapp.fxform.adapter;
+
+public class IntegerToDoubleAdapter implements Adapter<Integer, Double> {
+
+    @Override
+    public Double adaptTo(Integer from) {
+        return from.doubleValue();
+    }
+
+    @Override
+    public Integer adaptFrom(Double to) {
+        return to.intValue();
+    }
+}


### PR DESCRIPTION
Here is a memory leak illustrated by the following the reference chain :

`DefaultAdapterProvider > DEFAULT_MAP (static) > Anonymous class > DefaultAdapterProvider > USER_MAP > Anonymous class > Outer class.`
And the visual VM screen : https://img15.hostingpics.net/pics/554777screen.png

It means : if an inner anonymous instance is used and set into the USER_MAP, it will prevent the outer instance to be garbage collected since the DEFAULT_MAP is static.

Resolution : use explicite defined classes instead of anonymous classes in DefaultAdapterProvider implementation.

I was unfortunatly unable to reproduce it in a unit test so I added more documentation.