### PR TITLE
The FXFormNode could never be initialized

### DIFF
--- a/core/src/main/java/com/dooapp/fxform/view/FXFormNodeWrapper.java
+++ b/core/src/main/java/com/dooapp/fxform/view/FXFormNodeWrapper.java
@@ -75,10 +75,6 @@ public class FXFormNodeWrapper implements FXFormNode {
         return property;
     }
 
-
-    public void init(Element element) {
-    }
-
     @Override
     public void init(Element element, AbstractFXForm fxForm) {
     }

--- a/core/src/main/java/com/dooapp/fxform/view/factory/impl/PaginatedTableViewFactory.java
+++ b/core/src/main/java/com/dooapp/fxform/view/factory/impl/PaginatedTableViewFactory.java
@@ -1,5 +1,6 @@
 package com.dooapp.fxform.view.factory.impl;
 
+import com.dooapp.fxform.AbstractFXForm;
 import com.dooapp.fxform.model.Element;
 import com.dooapp.fxform.reflection.ReflectionUtils;
 import com.dooapp.fxform.view.FXFormNode;
@@ -26,7 +27,7 @@ public class PaginatedTableViewFactory implements Callback<Void, FXFormNode> {
 
         return new FXFormNodeWrapper(paginatedTableView, paginatedTableView.itemsProperty()) {
             @Override
-            public void init(Element element) {
+            public void init(Element element, AbstractFXForm fxForm) {
                 Class wrappedType = element.getWrappedType();
                 List<Field> fields = ReflectionUtils.listFields(wrappedType);
                 for (Field field : fields) {

--- a/core/src/main/java/com/dooapp/fxform/view/factory/impl/TableViewFactory.java
+++ b/core/src/main/java/com/dooapp/fxform/view/factory/impl/TableViewFactory.java
@@ -12,6 +12,7 @@
 
 package com.dooapp.fxform.view.factory.impl;
 
+import com.dooapp.fxform.AbstractFXForm;
 import com.dooapp.fxform.model.Element;
 import com.dooapp.fxform.reflection.ReflectionUtils;
 import com.dooapp.fxform.view.FXFormNode;
@@ -39,7 +40,7 @@ public class TableViewFactory implements Callback<Void, FXFormNode> {
 
         return new FXFormNodeWrapper(tableView, new TableViewProperty(tableView)) {
             @Override
-            public void init(Element element) {
+            public void init(Element element, AbstractFXForm fxForm) {
                 Class wrappedType = element.getWrappedType();
                 List<Field> fields = ReflectionUtils.listFields(wrappedType);
                 for (Field field : fields) {

--- a/core/src/test/java/com/dooapp/fxform/issues/Issue161Test.java
+++ b/core/src/test/java/com/dooapp/fxform/issues/Issue161Test.java
@@ -1,0 +1,64 @@
+package com.dooapp.fxform.issues;
+
+import com.dooapp.fxform.AbstractFXForm;
+import com.dooapp.fxform.FXForm;
+import com.dooapp.fxform.JavaFXRule;
+import com.dooapp.fxform.handler.NamedFieldHandler;
+import com.dooapp.fxform.model.Element;
+import com.dooapp.fxform.view.FXFormNode;
+import com.dooapp.fxform.view.FXFormNodeWrapper;
+import com.dooapp.fxform.view.factory.DefaultFactoryProvider;
+import javafx.beans.property.SimpleStringProperty;
+import javafx.beans.property.StringProperty;
+import javafx.scene.control.TextField;
+import javafx.util.Callback;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class Issue161Test {
+
+    @Rule
+    public JavaFXRule javaFXRule = new JavaFXRule();
+
+    public class TestBean {
+        private StringProperty text = new SimpleStringProperty();
+
+        public String getText() {
+            return text.get();
+        }
+
+        public StringProperty textProperty() {
+            return text;
+        }
+
+        public void setText(String text) {
+            this.text.set(text);
+        }
+    }
+
+    @Test
+    public void test() {
+        TextField textArea = new TextField();
+        FXForm form = new FXForm();
+
+        DefaultFactoryProvider factoryProvider = (DefaultFactoryProvider) form.getEditorFactoryProvider();
+        factoryProvider.addFactory(new NamedFieldHandler("text"), new Callback<Void, FXFormNode>() {
+            @Override
+            public FXFormNode call(Void param) {
+                return new FXFormNodeWrapper(textArea, textArea.textProperty()) {
+                    @Override
+                    public void init(Element element, AbstractFXForm fxForm) {
+                        super.init(element, fxForm);
+                        textArea.setPromptText("DOOAPP");
+                    }
+                };
+            }
+        });
+
+        TestBean testBean = new TestBean();
+        form.setSource(testBean);
+
+        Assert.assertEquals("DOOAPP", textArea.getPromptText());
+    }
+}

--- a/samples/src/main/java/com/dooapp/fxform/samples/CustomFactoryForm.java
+++ b/samples/src/main/java/com/dooapp/fxform/samples/CustomFactoryForm.java
@@ -1,5 +1,6 @@
 package com.dooapp.fxform.samples;
 
+import com.dooapp.fxform.AbstractFXForm;
 import com.dooapp.fxform.FXForm;
 import com.dooapp.fxform.FXFormSample;
 import com.dooapp.fxform.Utils;
@@ -36,7 +37,7 @@ public class CustomFactoryForm extends FXFormSample {
         String value() default "";
     }
 
-    public class TextFieldWithPromptTextFactory implements Callback<Void, FXFormNode> {
+    public static class TextFieldWithPromptTextFactory implements Callback<Void, FXFormNode> {
 
         @Override
         public FXFormNode call(Void param) {
@@ -44,8 +45,8 @@ public class CustomFactoryForm extends FXFormSample {
             return new FXFormNodeWrapper(textField, textField.textProperty()) {
 
                 @Override
-                public void init(Element element) {
-                    super.init(element);
+                public void init(Element element, AbstractFXForm fxForm) {
+                    super.init(element, fxForm);
                     PromptText promptText = (PromptText) element.getAnnotation(PromptText.class);
                     textField.setPromptText(promptText.value());
                 }
@@ -65,7 +66,7 @@ public class CustomFactoryForm extends FXFormSample {
         public IntegerProperty age = new SimpleIntegerProperty(10);
 
         @FormFactory(TextFieldWithPromptTextFactory.class)
-        @PromptText("Please select a funny hobby")
+        @PromptText("Please write a funny hobby")
         public StringProperty hobby = new SimpleStringProperty();
 
     }
@@ -82,8 +83,10 @@ public class CustomFactoryForm extends FXFormSample {
         UserWithCustomFactory userWithCustomFactory = new UserWithCustomFactory();
         // another way to register a custom factory using the DefaultFactoryProvider
         DefaultFactoryProvider factoryProvider = new DefaultFactoryProvider();
-        factoryProvider.addFactory(element -> true,
-                new ListChoiceBoxFactory<>(new SimpleListProperty<>(FXCollections.observableArrayList("Robert", "Jon", "Catelyn"))));
+        factoryProvider.addFactory(
+                element -> element.getName().equals("firstName"),
+                new ListChoiceBoxFactory<>(new SimpleListProperty<>(FXCollections.observableArrayList("Robert", "Jon", "Catelyn")))
+        );
         form.setEditorFactoryProvider(factoryProvider);
         form.setSource(userWithCustomFactory);
         root.getChildren().add(form);


### PR DESCRIPTION
Following #157 the FXFormNode.init() method has been extended with a new parameter but hasn't been removed in the default implementation. That causes init(Element) to never be call anymore if the user use a specific implementation of FXFormNodeWrapper.

What's has been done in this commit : 
- fix CustomFactoryForm section in the sample project : TextFieldWithPromptTextFactory was never instanciate and all elements were a combobox
- at this part there is no prompt text displayed to the hobby despite the custom factory. So fix FXFormNodeWrapper.