### PR TITLE
Apply ExcludeFilter even if one the contained element is invalid (#197)

### DIFF
--- a/core/src/main/java/com/dooapp/fxform/filter/ExcludeFilter.java
+++ b/core/src/main/java/com/dooapp/fxform/filter/ExcludeFilter.java
@@ -16,20 +16,28 @@ import com.dooapp.fxform.model.Element;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * User: Antoine Mischler <antoine@dooapp.com> Date: 12/09/11 Time: 15:10
  */
 public class ExcludeFilter extends AbstractNameFilter implements ElementListFilter {
 
+	public final static Logger logger = Logger.getLogger(ExcludeFilter.class.getName());
+
 	public ExcludeFilter(String... names) {
 		super(names);
 	}
 
 	public List<Element> filter(List<Element> toFilter) throws FilterException {
-		List<Element> filtered = new ArrayList<Element>(toFilter);
+		List<Element> filtered = new ArrayList<>(toFilter);
 		for (String name : names) {
-			extractFieldByName(filtered, name);
+			try {
+				extractFieldByName(filtered, name);
+			} catch (FilterException e) {
+				logger.log(Level.WARNING, e.getMessage(), e);
+			}
 		}
 		return filtered;
 	}

--- a/core/src/test/java/com/dooapp/fxform/issues/Issue197Test.java
+++ b/core/src/test/java/com/dooapp/fxform/issues/Issue197Test.java
@@ -1,0 +1,54 @@
+package com.dooapp.fxform.issues;
+
+import com.dooapp.fxform.FXForm;
+import com.dooapp.fxform.JavaFXRule;
+import com.dooapp.fxform.filter.ExcludeFilter;
+import javafx.beans.property.SimpleStringProperty;
+import javafx.beans.property.StringProperty;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class Issue197Test {
+
+    @Rule
+    public JavaFXRule javaFXRule = new JavaFXRule();
+
+    public class Bean {
+        private StringProperty a = new SimpleStringProperty();
+        private StringProperty b = new SimpleStringProperty();
+
+        public String getA() { return a.get(); }
+        public StringProperty aProperty() { return a; }
+        public void setA(String a) { this.a.set(a); }
+
+        public String getB() { return b.get(); }
+        public StringProperty bProperty() { return b; }
+        public void setB(String b) { this.b.set(b); }
+    }
+
+    @Test
+    public void test() {
+        Bean bean = new Bean();
+        FXForm<Bean> form = new FXForm<>();
+        form.setSource(bean);
+        Assert.assertEquals(2, form.getFilteredElements().size());
+        Assert.assertEquals("a", form.getFilteredElements().get(0).getName());
+        Assert.assertEquals("b", form.getFilteredElements().get(1).getName());
+
+        ExcludeFilter excludeFilter = new ExcludeFilter("a");
+        form.getFilters().setAll(excludeFilter);
+        Assert.assertEquals(1, form.getFilteredElements().size());
+        Assert.assertEquals("b", form.getFilteredElements().get(0).getName());
+
+        excludeFilter = new ExcludeFilter("a", "c");
+        form.getFilters().setAll(excludeFilter);
+        Assert.assertEquals(1, form.getFilteredElements().size());
+        Assert.assertEquals("b", form.getFilteredElements().get(0).getName());
+
+        form.getFilters().clear();
+        Assert.assertEquals(2, form.getFilteredElements().size());
+        Assert.assertEquals("a", form.getFilteredElements().get(0).getName());
+        Assert.assertEquals("b", form.getFilteredElements().get(1).getName());
+    }
+}


### PR DESCRIPTION
On a form that define an ExcludeFilter, all field names had to be correct and present in the source to apply the filter. If one of  the element is not valid, the filter was not applied at all.

The pull request improve that behavior by applying the filter at least on valid elements.