### PR TITLE
Instantiate DefaultAdapterProvider multiple times initialize DEFAULT_MAP more than once

### DIFF
--- a/core/src/main/java/com/dooapp/fxform/adapter/AdapterProvider.java
+++ b/core/src/main/java/com/dooapp/fxform/adapter/AdapterProvider.java
@@ -31,6 +31,6 @@ public interface AdapterProvider {
      * @param fxFormNode
      * @return
      */
-    public Adapter getAdapter(Class fromClass, Class toClass, Element element, FXFormNode fxFormNode);
+    Adapter getAdapter(Class fromClass, Class toClass, Element element, FXFormNode fxFormNode);
 
 }

--- a/core/src/main/java/com/dooapp/fxform/adapter/DefaultAdapterProvider.java
+++ b/core/src/main/java/com/dooapp/fxform/adapter/DefaultAdapterProvider.java
@@ -38,7 +38,7 @@ public class DefaultAdapterProvider implements AdapterProvider {
 
     private final Map<AdapterMatcher, Adapter> USER_MAP = new ConcurrentHashMap<>();
 
-    {
+    static {
         // Make sure to not add a new adapter as anonymous inner class in the DEFAULT_MAP.
         // That could cause memory leak since an inner instance keeps a reference to its outer instance.
 

--- a/core/src/test/java/com/dooapp/fxform/issues/Issue198Test.java
+++ b/core/src/test/java/com/dooapp/fxform/issues/Issue198Test.java
@@ -1,0 +1,57 @@
+package com.dooapp.fxform.issues;
+
+import com.dooapp.fxform.FXForm;
+import com.dooapp.fxform.JavaFXRule;
+import com.dooapp.fxform.adapter.Adapter;
+import com.dooapp.fxform.adapter.AdapterMatcher;
+import javafx.beans.property.SimpleStringProperty;
+import javafx.beans.property.StringProperty;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.lang.reflect.Field;
+import java.util.Map;
+
+public class Issue198Test {
+
+    @Rule
+    public JavaFXRule javaFXRule = new JavaFXRule();
+
+    @Test
+    public void testToInstantiateMultipleDefaultAdapterProvider() throws NoSuchFieldException, IllegalAccessException {
+        // Create DefaultAdapterProvider for the first time and get "DEFAULT_MAP" map size
+        FXForm firstForm = new FXForm<>();
+        firstForm.setSource(new Bean());
+        Field defaultMapField = firstForm.getAdapterProvider().getClass().getDeclaredField("DEFAULT_MAP");
+        defaultMapField.setAccessible(true);
+        int size1 = ((Map<AdapterMatcher, Adapter>) defaultMapField.get(firstForm.getAdapterProvider())).size();
+
+        // Create DefaultAdapterProvider for the second time and get "DEFAULT_MAP" map size
+        FXForm form2 = new FXForm<>();
+        form2.setSource(new Bean());
+        Field defaultMapField2 = form2.getAdapterProvider().getClass().getDeclaredField("DEFAULT_MAP");
+        defaultMapField2.setAccessible(true);
+        int size2 = ((Map<AdapterMatcher, Adapter>) defaultMapField2.get(form2.getAdapterProvider())).size();
+
+        // Because DEFAULT_MAP contains generic static adapter matchers it must not have more elements the second
+        // time an instance is created
+        Assert.assertEquals(size1, size2);
+    }
+
+    public class Bean {
+        private StringProperty text = new SimpleStringProperty();
+
+        public String getText() {
+            return text.get();
+        }
+
+        public StringProperty textProperty() {
+            return text;
+        }
+
+        public void setText(String text) {
+            this.text.set(text);
+        }
+    }
+}


### PR DESCRIPTION
This PR follows a change done in  #122 that used an **Instance initialization block** instead of a **Static initialization block**. But only static initialization block is called one (at the time of class loading). More explanation are available here : https://www.benchresources.net/java-initialization-blocks/

So I fixed this just by changing the code to use a static block.

**Note :** 
I applied the change only to the DefaultAdapterProvider and not DefaultFactoryProvider. Problem probably also exist on this class but I prefered for now only modified a class where I reproduced a problem. In addition the init block of DefaultFactoryProvider has a reference to "this", which need probably more reflexion.