### PR TITLE
An element does not become invalid in case of non-adaptable input #207

### DIFF
--- a/core/src/main/java/com/dooapp/fxform/validation/PropertyElementValidator.java
+++ b/core/src/main/java/com/dooapp/fxform/validation/PropertyElementValidator.java
@@ -15,6 +15,7 @@ package com.dooapp.fxform.validation;
 import com.dooapp.fxform.adapter.Adapter;
 import com.dooapp.fxform.adapter.AdapterException;
 import com.dooapp.fxform.model.PropertyElement;
+import javafx.beans.binding.Bindings;
 import javafx.beans.property.*;
 import javafx.beans.value.ChangeListener;
 import javafx.beans.value.ObservableValue;
@@ -34,11 +35,11 @@ public class PropertyElementValidator {
 
     private final PropertyElement element;
 
-    private final ObjectProperty<FXFormValidator> validator = new SimpleObjectProperty<FXFormValidator>();
+    private final ObjectProperty<FXFormValidator> validator = new SimpleObjectProperty<>();
 
-    private final ListProperty<ConstraintViolation> constraintViolations = new SimpleListProperty<>(FXCollections.synchronizedObservableList(FXCollections.<ConstraintViolation>observableArrayList()));
+    private final ListProperty<ConstraintViolation> constraintViolations = new SimpleListProperty<>(FXCollections.synchronizedObservableList(FXCollections.observableArrayList()));
 
-    private final ListProperty<ConstraintViolation> classLevelConstraintViolations = new SimpleListProperty<ConstraintViolation>(FXCollections.synchronizedObservableList(FXCollections.<ConstraintViolation>observableArrayList()));
+    private final ListProperty<ConstraintViolation> classLevelConstraintViolations = new SimpleListProperty<>(FXCollections.synchronizedObservableList(FXCollections.observableArrayList()));
 
     private final BooleanProperty invalid = new SimpleBooleanProperty(false);
 
@@ -54,6 +55,7 @@ public class PropertyElementValidator {
                 validate(element.getValue());
             }
         });
+        invalid.bind(Bindings.isNotEmpty(constraintViolations));
     }
 
     public Object adapt(final Object newValue, Adapter adapter) throws AdapterException {
@@ -76,7 +78,6 @@ public class PropertyElementValidator {
         if (validator != null) {
             // Validate strict constraints that prevent the model value from being updated
             constraintViolations.addAll(validator.validate(element, newValue));
-            invalid.set(!constraintViolations.isEmpty());
             // Validate warnings constraints
             List<ConstraintViolation> warningList = validator.validate(element, newValue, Warning.class);
             warning.set(!warningList.isEmpty());
@@ -92,12 +93,10 @@ public class PropertyElementValidator {
      */
     public List<ConstraintViolation> reportClassLevelConstraintViolation(List<ConstraintViolation> violations) {
         constraintViolations.removeAll(classLevelConstraintViolations);
-        invalid.set(!constraintViolations.isEmpty());
         classLevelConstraintViolations.clear();
         for (ConstraintViolation constraintViolation : violations) {
             if (isRelated(constraintViolation)) {
                 classLevelConstraintViolations.add(constraintViolation);
-                invalid.set(true);
             }
         }
         constraintViolations.addAll(classLevelConstraintViolations);

--- a/core/src/test/java/com/dooapp/fxform/issues/Issue207Test.java
+++ b/core/src/test/java/com/dooapp/fxform/issues/Issue207Test.java
@@ -1,0 +1,52 @@
+package com.dooapp.fxform.issues;
+
+import com.dooapp.fxform.FXForm;
+import com.dooapp.fxform.JavaFXRule;
+import javafx.beans.property.IntegerProperty;
+import javafx.beans.property.SimpleIntegerProperty;
+import javafx.scene.control.Label;
+import javafx.scene.control.TextField;
+import org.hamcrest.core.IsNot;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static org.junit.Assert.assertThat;
+import static org.junit.internal.matchers.IsCollectionContaining.hasItems;
+
+public class Issue207Test {
+
+    @Rule
+    public JavaFXRule javaFXRule = new JavaFXRule();
+
+    public class Bean {
+
+        private IntegerProperty year = new SimpleIntegerProperty();
+
+        public int getYear() {
+            return year.get();
+        }
+
+        public IntegerProperty yearProperty() {
+            return year;
+        }
+
+        public void setYear(int year) {
+            this.year.set(year);
+        }
+    }
+
+    @Test
+    public void testThatElementBecomeInvalidWhenInputCannotBeAdapted() {
+        Bean bean = new Bean();
+        FXForm<Bean> form = new FXForm<>();
+        form.setSource(bean);
+
+        Label yearLabel = (Label) form.lookup("#year-form-label");
+        assertThat(yearLabel.getStyleClass(), IsNot.not(hasItems("form-label-invalid")));
+
+        TextField yearEditor = (TextField) form.lookup("#year-form-editor");
+        yearEditor.setText("azerty");
+
+        assertThat(yearLabel.getStyleClass(), hasItems("form-label-invalid"));
+    }
+}


### PR DESCRIPTION
Reproduction: 
- Create a form with a source model that contains an IntegerProperty
- Define a custom CSS that will change the style if element become invalid (.form-label-invalid, .form-editor-invalid...)
- Fill value from the view with a non-adaptable value, such a String

Problem:
-  Invalid CSS style is not applied on the element