### PR TITLE
Save value in the model for warning constraint violations

### DIFF
--- a/core/src/main/java/com/dooapp/fxform/validation/PropertyElementValidator.java
+++ b/core/src/main/java/com/dooapp/fxform/validation/PropertyElementValidator.java
@@ -15,10 +15,8 @@ package com.dooapp.fxform.validation;
 import com.dooapp.fxform.adapter.Adapter;
 import com.dooapp.fxform.adapter.AdapterException;
 import com.dooapp.fxform.model.PropertyElement;
-import javafx.beans.binding.Bindings;
+import javafx.beans.binding.BooleanBinding;
 import javafx.beans.property.*;
-import javafx.beans.value.ChangeListener;
-import javafx.beans.value.ObservableValue;
 import javafx.collections.FXCollections;
 
 import javax.validation.ConstraintViolation;
@@ -50,7 +48,20 @@ public class PropertyElementValidator {
     public PropertyElementValidator(final PropertyElement element) {
         this.element = element;
         validator.addListener((observableValue, validator, validator2) -> validate(element.getValue()));
-        invalid.bind(Bindings.isNotEmpty(constraintViolations));
+        invalid.bind(new BooleanBinding() {
+            {
+                super.bind(constraintViolations);
+            }
+
+            @Override
+            protected boolean computeValue() {
+                boolean result = constraintViolations.stream()
+                        .anyMatch(constraintViolation -> constraintViolation instanceof NotAdaptableInputValue
+                                || (constraintViolation.getConstraintDescriptor() != null
+                                && !constraintViolation.getConstraintDescriptor().getGroups().contains(Warning.class)));
+                return result;
+            }
+        });
     }
 
     public Object adapt(final Object newValue, Adapter adapter) throws AdapterException {

--- a/core/src/test/java/com/dooapp/fxform/issues/Issue208Test.java
+++ b/core/src/test/java/com/dooapp/fxform/issues/Issue208Test.java
@@ -1,0 +1,70 @@
+package com.dooapp.fxform.issues;
+
+import com.dooapp.fxform.AbstractFXForm;
+import com.dooapp.fxform.FXForm;
+import com.dooapp.fxform.JavaFXRule;
+import com.dooapp.fxform.handler.NamedFieldHandler;
+import com.dooapp.fxform.model.Element;
+import com.dooapp.fxform.validation.Warning;
+import com.dooapp.fxform.view.FXFormNode;
+import com.dooapp.fxform.view.FXFormNodeWrapper;
+import com.dooapp.fxform.view.factory.DefaultFactoryProvider;
+import javafx.beans.property.IntegerProperty;
+import javafx.beans.property.SimpleIntegerProperty;
+import javafx.scene.control.TextField;
+import javafx.util.Callback;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+
+import javax.validation.constraints.Max;
+
+public class Issue208Test {
+
+    @Rule
+    public JavaFXRule javaFXRule = new JavaFXRule();
+
+    public class Bean {
+
+        private IntegerProperty year = new SimpleIntegerProperty();
+
+        @Max(value = 2025, groups = Warning.class)
+        public int getYear() {
+            return year.get();
+        }
+
+        public IntegerProperty yearProperty() {
+            return year;
+        }
+
+        public void setYear(int year) {
+            this.year.set(year);
+        }
+    }
+
+    @Test
+    public void testThatWarningStyleClassIsWellAddedAtFormInitialization() {
+        FXForm form = new FXForm<>();
+
+        TextField textField = new TextField();
+        DefaultFactoryProvider factoryProvider = (DefaultFactoryProvider) form.getEditorFactoryProvider();
+        factoryProvider.addFactory(new NamedFieldHandler("year"), new Callback<Void, FXFormNode>() {
+            @Override
+            public FXFormNode call(Void param) {
+                return new FXFormNodeWrapper(textField, textField.textProperty()) {
+                    @Override
+                    public void init(Element element, AbstractFXForm fxForm) {
+                        super.init(element, fxForm);
+                        textField.setPromptText("YEAR");
+                    }
+                };
+            }
+        });
+
+        Bean bean = new Bean();
+        form.setSource(bean);
+
+        textField.setText("2030");
+        Assert.assertEquals(textField.getText(), String.valueOf(bean.getYear()));
+    }
+}


### PR DESCRIPTION
This functionality always worked until the changes made in issue #207 . It has been corrected and there is a unit test added to verify this case always works in the future.